### PR TITLE
Change wiremock dependency group name

### DIFF
--- a/part2.2-rest/build.gradle
+++ b/part2.2-rest/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     testImplementation project(':commons')
     testImplementation project(':commons-rest')
     testImplementation 'org.spockframework:spock-spring:2.4-M1-groovy-4.0'
-    testImplementation 'com.github.tomakehurst:wiremock:3.0.1'
+    testImplementation 'org.wiremock:wiremock:3.3.1'
 }
 
 test {


### PR DESCRIPTION
According to https://mvnrepository.com/artifact/com.github.tomakehurst/wiremock and https://wiremock.org/docs/download-and-installation/ wiremock artifact was moved to new group. 