### PR TITLE
Hermes mock without rules and with random port

### DIFF
--- a/part2.3-message-broker/build.gradle
+++ b/part2.3-message-broker/build.gradle
@@ -27,7 +27,6 @@ dependencies {
     testImplementation project(':commons')
     testImplementation project(':commons-rest')
     testImplementation 'pl.allegro.tech.hermes:hermes-mock:2.5.2'
-    testImplementation 'org.spockframework:spock-junit4:2.4-M1-groovy-4.0'
     testImplementation 'org.spockframework:spock-spring:2.4-M1-groovy-4.0'
 }
 

--- a/part2.3-message-broker/src/test/groovy/pl/allegro/tech/workshops/testsparallelexecution/email/messagebroker/EmailsByMessageBrokerResourceTest.groovy
+++ b/part2.3-message-broker/src/test/groovy/pl/allegro/tech/workshops/testsparallelexecution/email/messagebroker/EmailsByMessageBrokerResourceTest.groovy
@@ -1,6 +1,9 @@
 package pl.allegro.tech.workshops.testsparallelexecution.email.messagebroker
 
+import org.spockframework.spring.EnableSharedInjection
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Import
 import pl.allegro.tech.hermes.mock.HermesMock
 import pl.allegro.tech.workshops.testsparallelexecution.BaseTestWithRest
 import spock.lang.Shared
@@ -11,13 +14,16 @@ import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
 import static org.springframework.http.HttpStatus.OK
 import static pl.allegro.tech.hermes.mock.exchange.Response.Builder.aResponse
 
-class EmailsByMessageBrokerResourceTest extends BaseTestWithRest {
+@EnableSharedInjection
+@Import(HermesMockConfig)
+class EmailsByMessageBrokerResourceTest extends BaseTestWithRest implements HermesMockPortSupport {
 
     @Value('${application.services.message-broker.topic}')
     private String topic
 
     @Shared
-    private HermesMock hermesMock = new HermesMock.Builder().withPort(8089).build()
+    @Autowired
+    private HermesMock hermesMock
 
     def setupSpec() {
         hermesMock.start()

--- a/part2.3-message-broker/src/test/groovy/pl/allegro/tech/workshops/testsparallelexecution/email/messagebroker/EmailsByMessageBrokerResourceTest.groovy
+++ b/part2.3-message-broker/src/test/groovy/pl/allegro/tech/workshops/testsparallelexecution/email/messagebroker/EmailsByMessageBrokerResourceTest.groovy
@@ -1,8 +1,7 @@
 package pl.allegro.tech.workshops.testsparallelexecution.email.messagebroker
 
-import org.junit.ClassRule
 import org.springframework.beans.factory.annotation.Value
-import pl.allegro.tech.hermes.mock.HermesMockRule
+import pl.allegro.tech.hermes.mock.HermesMock
 import pl.allegro.tech.workshops.testsparallelexecution.BaseTestWithRest
 import spock.lang.Shared
 
@@ -17,9 +16,16 @@ class EmailsByMessageBrokerResourceTest extends BaseTestWithRest {
     @Value('${application.services.message-broker.topic}')
     private String topic
 
-    @ClassRule
     @Shared
-    private HermesMockRule hermesMock = new HermesMockRule(8089)
+    private HermesMock hermesMock = new HermesMock.Builder().withPort(8089).build()
+
+    def setupSpec() {
+        hermesMock.start()
+    }
+
+    def cleanupSpec() {
+        hermesMock.stop()
+    }
 
     private String subject = "New workshops!"
 

--- a/part2.3-message-broker/src/test/groovy/pl/allegro/tech/workshops/testsparallelexecution/email/messagebroker/HermesMockConfig.groovy
+++ b/part2.3-message-broker/src/test/groovy/pl/allegro/tech/workshops/testsparallelexecution/email/messagebroker/HermesMockConfig.groovy
@@ -1,0 +1,14 @@
+package pl.allegro.tech.workshops.testsparallelexecution.email.messagebroker
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import pl.allegro.tech.hermes.mock.HermesMock
+
+@TestConfiguration
+class HermesMockConfig {
+    @Bean
+    HermesMock getHermesMock(@Value('${hermes-mock.port}') int hermesMockPort) {
+        return new HermesMock.Builder().withPort(hermesMockPort).build()
+    }
+}

--- a/part2.3-message-broker/src/test/groovy/pl/allegro/tech/workshops/testsparallelexecution/email/messagebroker/HermesMockPortSupport.groovy
+++ b/part2.3-message-broker/src/test/groovy/pl/allegro/tech/workshops/testsparallelexecution/email/messagebroker/HermesMockPortSupport.groovy
@@ -1,0 +1,14 @@
+package pl.allegro.tech.workshops.testsparallelexecution.email.messagebroker
+
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.util.TestSocketUtils
+
+trait HermesMockPortSupport {
+
+    @DynamicPropertySource
+    static void configurePort(DynamicPropertyRegistry registry) {
+        int port = TestSocketUtils.findAvailableTcpPort()
+        registry.add("hermes-mock.port", () -> port)
+    }
+}

--- a/part2.3-message-broker/src/test/resources/application.yml
+++ b/part2.3-message-broker/src/test/resources/application.yml
@@ -1,2 +1,2 @@
-application.services.message-broker.url: http://localhost:8089
+application.services.message-broker.url: http://localhost:${hermes-mock.port}
 application.services.message-broker.topic: pl.allegro.tech.workshops.testsparallelexecution.email


### PR DESCRIPTION
One user had problems with tests in module 2.3. This change starts HermesMock without JUnit rule and additionally starts HermesMock with random port. 

```
java.util.concurrent.ExecutionException: java.lang.IllegalStateException: STOPPED
	at java.base/java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:396)
	at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2096)
	at org.eclipse.jetty.server.Server.doStop(Server.java:490)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.stop(AbstractLifeCycle.java:132)
	at com.github.tomakehurst.wiremock.jetty.JettyHttpServer.stop(JettyHttpServer.java:228)
	at com.github.tomakehurst.wiremock.WireMockServer.stop(WireMockServer.java:151)
	at pl.allegro.tech.hermes.mock.HermesMock.stop(HermesMock.java:86)
	at pl.allegro.tech.hermes.mock.HermesMockRule.destroyInitialContext(HermesMockRule.java:82)
	at pl.allegro.tech.hermes.mock.HermesMockRule$1.evaluate(HermesMockRule.java:70)
	at org.spockframework.junit4.AbstractRuleInterceptor.evaluateStatement(AbstractRuleInterceptor.java:66)
	at org.spockframework.junit4.ClassRuleInterceptor.intercept(ClassRuleInterceptor.java:44)
	at org.spockframework.runtime.extension.MethodInvocation.proceed(MethodInvocation.java:101)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:35)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:54)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:147)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:127)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:90)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:55)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:102)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:54)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:114)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:86)
	at org.junit.platform.launcher.core.DefaultLauncherSession$DelegatingLauncher.execute(DefaultLauncherSession.java:86)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.processAllTestClasses(JUnitPlatformTestClassProcessor.java:119)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.access$000(JUnitPlatformTestClassProcessor.java:94)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor.stop(JUnitPlatformTestClassProcessor.java:89)
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.stop(SuiteTestClassProcessor.java:62)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker$3.run(TestWorker.java:193)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.executeAndMaintainThreadName(TestWorker.java:129)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:100)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:60)
	at org.gradle.process.internal.worker.child.ActionExecutionWorker.execute(ActionExecutionWorker.java:56)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:113)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:65)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.run(GradleWorkerMain.java:69)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.main(GradleWorkerMain.java:74)
Caused by: java.lang.IllegalStateException: STOPPED
	at org.eclipse.jetty.server.handler.ContextHandler.shutdown(ContextHandler.java:774)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1625)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:575)
	at java.base/java.util.stream.AbstractPipeline.evaluateToArrayNode(AbstractPipeline.java:260)
	at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:616)
	at org.eclipse.jetty.util.component.Graceful.shutdown(Graceful.java:146)
	... 53 more


STOPPED
java.lang.IllegalStateException: STOPPED
	at org.eclipse.jetty.server.handler.ContextHandler.shutdown(ContextHandler.java:774)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1625)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:575)
	at java.base/java.util.stream.AbstractPipeline.evaluateToArrayNode(AbstractPipeline.java:260)
	at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:616)
	at org.eclipse.jetty.util.component.Graceful.shutdown(Graceful.java:146)
	at org.eclipse.jetty.server.Server.doStop(Server.java:490)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.stop(AbstractLifeCycle.java:132)
	at com.github.tomakehurst.wiremock.jetty.JettyHttpServer.stop(JettyHttpServer.java:228)
	at com.github.tomakehurst.wiremock.WireMockServer.stop(WireMockServer.java:151)
	at pl.allegro.tech.hermes.mock.HermesMock.stop(HermesMock.java:86)
	at pl.allegro.tech.hermes.mock.HermesMockRule.destroyInitialContext(HermesMockRule.java:82)
	at pl.allegro.tech.hermes.mock.HermesMockRule$1.evaluate(HermesMockRule.java:70)
	at org.spockframework.junit4.AbstractRuleInterceptor.evaluateStatement(AbstractRuleInterceptor.java:66)
	at org.spockframework.junit4.ClassRuleInterceptor.intercept(ClassRuleInterceptor.java:44)
	at org.spockframework.runtime.extension.MethodInvocation.proceed(MethodInvocation.java:101)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:35)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:54)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:147)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:127)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:90)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:55)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:102)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:54)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:114)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:86)
	at org.junit.platform.launcher.core.DefaultLauncherSession$DelegatingLauncher.execute(DefaultLauncherSession.java:86)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.processAllTestClasses(JUnitPlatformTestClassProcessor.java:119)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.access$000(JUnitPlatformTestClassProcessor.java:94)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor.stop(JUnitPlatformTestClassProcessor.java:89)
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.stop(SuiteTestClassProcessor.java:62)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker$3.run(TestWorker.java:193)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.executeAndMaintainThreadName(TestWorker.java:129)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:100)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:60)
	at org.gradle.process.internal.worker.child.ActionExecutionWorker.execute(ActionExecutionWorker.java:56)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:113)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:65)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.run(GradleWorkerMain.java:69)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.main(GradleWorkerMain.java:74)
```