### PR TITLE
Upgrade Spring Boot to 3.2.1

### DIFF
--- a/commons-db/build.gradle
+++ b/commons-db/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java-library'
     id 'groovy'
-    id 'org.springframework.boot' version '3.1.5'
+    id 'org.springframework.boot' version '3.2.1'
     id 'io.spring.dependency-management' version '1.1.4'
 }
 

--- a/commons-rest/build.gradle
+++ b/commons-rest/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java-library'
     id 'groovy'
-    id 'org.springframework.boot' version '3.1.5'
+    id 'org.springframework.boot' version '3.2.1'
     id 'io.spring.dependency-management' version '1.1.4'
 }
 

--- a/part1.1-shared-state/build.gradle
+++ b/part1.1-shared-state/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'groovy'
-    id 'org.springframework.boot' version '3.1.5'
+    id 'org.springframework.boot' version '3.2.1'
     id 'io.spring.dependency-management' version '1.1.4'
     id 'io.github.platan.tests-execution-chart'
 }

--- a/part1.2-from-sequential-to-parallel/build.gradle
+++ b/part1.2-from-sequential-to-parallel/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'groovy'
-    id 'org.springframework.boot' version '3.1.5'
+    id 'org.springframework.boot' version '3.2.1'
     id 'io.spring.dependency-management' version '1.1.4'
     id 'io.github.platan.tests-execution-chart'
 }

--- a/part2.1-database/build.gradle
+++ b/part2.1-database/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'groovy'
-    id 'org.springframework.boot' version '3.1.5'
+    id 'org.springframework.boot' version '3.2.1'
     id 'io.spring.dependency-management' version '1.1.4'
     id 'io.github.platan.tests-execution-chart'
 }

--- a/part2.2-rest/build.gradle
+++ b/part2.2-rest/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'groovy'
-    id 'org.springframework.boot' version '3.1.5'
+    id 'org.springframework.boot' version '3.2.1'
     id 'io.spring.dependency-management' version '1.1.4'
     id 'io.github.platan.tests-execution-chart'
 }
@@ -25,7 +25,7 @@ dependencies {
     testImplementation project(':commons')
     testImplementation project(':commons-rest')
     testImplementation 'org.spockframework:spock-spring:2.4-M1-groovy-4.0'
-    testImplementation 'org.wiremock:wiremock:3.3.1'
+    testImplementation 'org.wiremock:wiremock-standalone:3.3.1'
 }
 
 test {

--- a/part2.2-rest/src/test/groovy/pl/allegro/tech/workshops/testsparallelexecution/email/rest/EmailsByRestResourceTest.groovy
+++ b/part2.2-rest/src/test/groovy/pl/allegro/tech/workshops/testsparallelexecution/email/rest/EmailsByRestResourceTest.groovy
@@ -122,7 +122,7 @@ class EmailsByRestResourceTest extends BaseTestWithRest {
         errorResponse                                             || expectedDetail
         aResponse().withStatus(400)                               || "400 Bad Request"
         aResponse().withStatus(500)                               || "500 Server Error"
-        aResponse().withFault(EMPTY_RESPONSE)                     || "failed to respond"
+        aResponse().withFault(EMPTY_RESPONSE)                     || "Unexpected end of file from server"
         aResponse().withFault(CONNECTION_RESET_BY_PEER)           || "Connection reset"
         aResponse().withFixedDelay(1000)
                 .withHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)

--- a/part2.3-message-broker/build.gradle
+++ b/part2.3-message-broker/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'groovy'
-    id 'org.springframework.boot' version '3.1.5'
+    id 'org.springframework.boot' version '3.2.1'
     id 'io.spring.dependency-management' version '1.1.4'
     id 'io.github.platan.tests-execution-chart'
 }
@@ -19,14 +19,14 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework:spring-webflux'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
-    implementation 'pl.allegro.tech.hermes:hermes-client:2.5.4'
+    implementation 'pl.allegro.tech.hermes:hermes-client:2.5.5'
     implementation 'org.eclipse.jetty:jetty-reactive-httpclient:4.0.2'
     implementation 'io.projectreactor.netty:reactor-netty:1.1.15'
 
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testImplementation project(':commons')
     testImplementation project(':commons-rest')
-    testImplementation 'pl.allegro.tech.hermes:hermes-mock:2.5.4'
+    testImplementation 'pl.allegro.tech.hermes:hermes-mock:2.5.5'
     testImplementation 'org.spockframework:spock-spring:2.4-M1-groovy-4.0'
 }
 


### PR DESCRIPTION
Updating dependencies of Spring Boot 3.2.1 caused some tests failing:
```
Caused by: org.springframework.beans.BeanInstantiationException: Failed to instantiate [pl.allegro.tech.hermes.mock.HermesMock]: Factory method 'getHermesMock' threw exception with message: class org.eclipse.jetty.http2.server.HttpChannelOverHTTP2 has interface org.eclipse.jetty.server.HttpChannel as super class
	at app//org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:177)
	at app//org.springframework.beans.factory.support.ConstructorResolver.instantiate(ConstructorResolver.java:651)
	... 35 more
Caused by: java.lang.IncompatibleClassChangeError: class org.eclipse.jetty.http2.server.HttpChannelOverHTTP2 has interface org.eclipse.jetty.server.HttpChannel as super class
	at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1012)
	at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:150)
	at java.base/jdk.internal.loader.BuiltinClassLoader.defineClass(BuiltinClassLoader.java:862)
	at java.base/jdk.internal.loader.BuiltinClassLoader.findClassOnClassPathOrNull(BuiltinClassLoader.java:760)
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:681)
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:639)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:520)
	at org.eclipse.jetty.http2.server.AbstractHTTP2ServerConnectionFactory.<init>(AbstractHTTP2ServerConnectionFactory.java:80)
	at org.eclipse.jetty.http2.server.HTTP2ServerConnectionFactory.<init>(HTTP2ServerConnectionFactory.java:53)
	at org.eclipse.jetty.http2.server.HTTP2CServerConnectionFactory.<init>(HTTP2CServerConnectionFactory.java:53)
	at org.eclipse.jetty.http2.server.HTTP2CServerConnectionFactory.<init>(HTTP2CServerConnectionFactory.java:48)
	at com.github.tomakehurst.wiremock.jetty11.Jetty11HttpServer.createHttpConnector(Jetty11HttpServer.java:53)
	at com.github.tomakehurst.wiremock.jetty.JettyHttpServer.<init>(JettyHttpServer.java:89)
	at com.github.tomakehurst.wiremock.jetty11.Jetty11HttpServer.<init>(Jetty11HttpServer.java:44)
	at com.github.tomakehurst.wiremock.jetty.JettyHttpServerFactory.buildHttpServer(JettyHttpServerFactory.java:31)
	at com.github.tomakehurst.wiremock.WireMockServer.<init>(WireMockServer.java:75)
	at com.github.tomakehurst.wiremock.WireMockServer.<init>(WireMockServer.java:117)
	at pl.allegro.tech.hermes.mock.HermesMock.<init>(HermesMock.java:32)
	at pl.allegro.tech.hermes.mock.HermesMock$Builder.build(HermesMock.java:119)
	at pl.allegro.tech.workshops.testsparallelexecution.email.messagebroker.HermesMockConfig.getHermesMock(HermesMockConfig.groovy:12)
	at org.springframework.cglib.proxy.MethodProxy.invokeSuper(MethodProxy.java:258)
	at org.springframework.context.annotation.ConfigurationClassEnhancer$BeanMethodInterceptor.intercept(ConfigurationClassEnhancer.java:331)
	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:140)
	... 36 more
```

As described in https://github.com/wiremock/wiremock/issues/2395:
> As a workaround, we can replace the wiremock package by the standalone one ( org.wiremock:wiremock-standalone ) 

Unfortunately this was not enough in our case, because hermes-mock still had dependency to non-standalone wiremock. 

This was changed in the recent release
https://github.com/allegro/hermes/releases/tag/hermes-2.5.5 (support for Spring Boot 3.2.1, wiremock replaced with the standalone version). 