### PR TITLE
Pass X-request-id header value

### DIFF
--- a/commons-rest/src/main/groovy/pl/allegro/tech/workshops/testsparallelexecution/support/Headers.groovy
+++ b/commons-rest/src/main/groovy/pl/allegro/tech/workshops/testsparallelexecution/support/Headers.groovy
@@ -1,0 +1,9 @@
+package pl.allegro.tech.workshops.testsparallelexecution.support
+
+final class Headers {
+
+    private Headers() {}
+
+    public static final String REQUEST_ID = 'X-request-id'
+
+}

--- a/commons-rest/src/main/groovy/pl/allegro/tech/workshops/testsparallelexecution/support/RestClient.groovy
+++ b/commons-rest/src/main/groovy/pl/allegro/tech/workshops/testsparallelexecution/support/RestClient.groovy
@@ -2,29 +2,49 @@ package pl.allegro.tech.workshops.testsparallelexecution.support
 
 import org.springframework.boot.test.web.client.TestRestTemplate
 import org.springframework.http.HttpEntity
-import org.springframework.http.HttpMethod
+import org.springframework.http.HttpHeaders
 import org.springframework.http.ResponseEntity
 
+import static org.springframework.http.HttpMethod.DELETE
+import static org.springframework.http.HttpMethod.GET
+import static org.springframework.http.HttpMethod.POST
 import static org.springframework.http.HttpMethod.PUT
 
 class RestClient {
     String url
     TestRestTemplate restTemplate
 
-    <T> ResponseEntity<T> get(String path, Class<T> responseType) {
-        restTemplate.getForEntity("$url$path", responseType)
+    <T> ResponseEntity<T> get(String path, Class<T> responseType, Map<String, String> headers = [:]) {
+        restTemplate.exchange("$url$path", GET, createHttpEntity(headers), responseType)
     }
 
-    <T> ResponseEntity<T> post(String path, Object request, Class<T> responseType) {
-        restTemplate.postForEntity("$url$path", request, responseType)
+    <T> ResponseEntity<T> post(String path, Object request, Class<T> responseType, Map<String, String> headers = [:]) {
+        restTemplate.exchange("$url$path", POST, createHttpEntity(request, headers), responseType)
     }
 
-    <T> ResponseEntity<T> put(String path, Object request, Class<T> responseType) {
-        restTemplate.exchange("$url$path", PUT, new HttpEntity(request), responseType)
+    <T> ResponseEntity<T> put(String path, Object request, Class<T> responseType, Map<String, String> headers = [:]) {
+        restTemplate.exchange("$url$path", PUT, createHttpEntity(request, headers), responseType)
     }
 
-    ResponseEntity<Void> delete(String path) {
-        restTemplate.exchange("$url$path", HttpMethod.DELETE, HttpEntity.EMPTY, Void)
+    ResponseEntity<Void> delete(String path, Map<String, String> headers = [:]) {
+        restTemplate.exchange("$url$path", DELETE, createHttpEntity(headers), Void)
     }
+
+    private static HttpEntity createHttpEntity(Object request, Map<String, String> headers) {
+        new HttpEntity(request, createHeaders(headers))
+    }
+
+    private static HttpEntity createHttpEntity(Map<String, String> headers = [:]) {
+        new HttpEntity(createHeaders(headers))
+    }
+
+    private static HttpHeaders createHeaders(Map<String, String> headers) {
+        new HttpHeaders().tap {
+            headers.each { header ->
+                set(header.key, header.value)
+            }
+        }
+    }
+
 
 }

--- a/part2.2-rest/src/main/java/pl/allegro/tech/workshops/testsparallelexecution/email/rest/ExternalEmailClient.java
+++ b/part2.2-rest/src/main/java/pl/allegro/tech/workshops/testsparallelexecution/email/rest/ExternalEmailClient.java
@@ -47,13 +47,16 @@ public class ExternalEmailClient implements EmailClient {
     }
 
     private static class PassRequestIdHeaderRequestInterceptor implements ClientHttpRequestInterceptor {
+
+        private static final String REQUEST_ID_HEADER_NAME = "X-request-id";
+
         @Override
         public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) throws IOException {
             RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
-            if (requestAttributes != null && requestAttributes instanceof ServletRequestAttributes) {
-                String requestId = ((ServletRequestAttributes) requestAttributes).getRequest().getHeader("X-request-id");
+            if (requestAttributes instanceof ServletRequestAttributes) {
+                String requestId = ((ServletRequestAttributes) requestAttributes).getRequest().getHeader(REQUEST_ID_HEADER_NAME);
                 HttpHeaders headers = request.getHeaders();
-                headers.set("X-request-id", requestId);
+                headers.set(REQUEST_ID_HEADER_NAME, requestId);
             }
             return execution.execute(request, body);
         }

--- a/part2.2-rest/src/main/java/pl/allegro/tech/workshops/testsparallelexecution/email/rest/ExternalEmailClient.java
+++ b/part2.2-rest/src/main/java/pl/allegro/tech/workshops/testsparallelexecution/email/rest/ExternalEmailClient.java
@@ -2,11 +2,20 @@ package pl.allegro.tech.workshops.testsparallelexecution.email.rest;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.retry.policy.MaxAttemptsRetryPolicy;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
+import java.io.IOException;
 import java.time.Duration;
 
 @Component
@@ -21,6 +30,7 @@ public class ExternalEmailClient implements EmailClient {
                 .rootUri(serviceUrl)
                 .setConnectTimeout(Duration.ofMillis(300))
                 .setReadTimeout(Duration.ofMillis(500))
+                .additionalInterceptors(new PassRequestIdHeaderRequestInterceptor())
                 .build();
         this.retryTemplate = new RetryTemplate();
         this.retryTemplate.setRetryPolicy(new MaxAttemptsRetryPolicy(2));
@@ -36,4 +46,16 @@ public class ExternalEmailClient implements EmailClient {
         return retryTemplate.execute(context -> restTemplate.getForEntity("/external-api-service/emails/" + id, Email.class).getBody());
     }
 
+    private static class PassRequestIdHeaderRequestInterceptor implements ClientHttpRequestInterceptor {
+        @Override
+        public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) throws IOException {
+            RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
+            if (requestAttributes != null && requestAttributes instanceof ServletRequestAttributes) {
+                String requestId = ((ServletRequestAttributes) requestAttributes).getRequest().getHeader("X-request-id");
+                HttpHeaders headers = request.getHeaders();
+                headers.set("X-request-id", requestId);
+            }
+            return execution.execute(request, body);
+        }
+    }
 }


### PR DESCRIPTION
The value of `X-request-id` header is passed from incoming request to external service. 
This feature can be used to parallelize tests (e.g. [GetEmailResourceTest](https://github.com/allegro/parallel-test-execution-workshop/blob/main/part2.2-rest/src/test/groovy/pl/allegro/tech/workshops/testsparallelexecution/email/rest/GetEmailResourceTest.groovy)) using a request id instead of request path or request body. 